### PR TITLE
added get article with comment-count

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -21,7 +21,7 @@ describe("GET /api", () => {
 });
 
 describe("GET /api/topics", () => {
-  test("200: Responses with an array of topic objects", () => {
+  test("200: Responds with an array of topic objects", () => {
     return request(app)
       .get("/api/topics")
       .expect(200)
@@ -42,7 +42,7 @@ describe("GET /api/topics", () => {
 });
 
 describe("GET /api/articles/:article_id", () => {
-  test("200: Responses with the correct article", () => {
+  test("200: Responds with the correct article", () => {
     return request(app)
       .get("/api/articles/1")
       .expect(200)
@@ -59,10 +59,11 @@ describe("GET /api/articles/:article_id", () => {
           votes: 100,
           article_img_url:
             "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+          comment_count: 11
         });
       });
   });
-  test("404: Responses with an error if article is not found", () => {
+  test("404: Responds with an error when an article is not found", () => {
     return request(app)
       .get("/api/articles/999999")
       .expect(404)
@@ -70,7 +71,7 @@ describe("GET /api/articles/:article_id", () => {
         expect(response.body.msg).toBe("Not Found");
       });
   });
-  test("400: Responses with an error if article_id is not a number", () => {
+  test("400: Responds with an error when an article_id is not a number", () => {
     return request(app)
       .get("/api/articles/dog")
       .expect(400)
@@ -78,11 +79,28 @@ describe("GET /api/articles/:article_id", () => {
         expect(response.body.msg).toBe("Bad Request");
       });
   });
+  test("200: Responds with an article including the comment-count", () => {
+      return request(app)
+        .get("/api/articles/1")
+        .expect(200)
+        .then((response) => {
+          const { article } = response.body;
+
+          expect(article).toHaveProperty("article_id", 1);
+          expect(article).toHaveProperty("title");
+          expect(article).toHaveProperty("topic");
+          expect(article).toHaveProperty("author");
+          expect(article).toHaveProperty("created_at");
+          expect(article).toHaveProperty("votes");
+          expect(article).toHaveProperty("article_img_url");
+          expect(article).toHaveProperty("comment_count", expect.any(Number));
+        });
+    });
 });
 
 
 describe("GET /api/articles", () => {
-  test("200: Responses with an array of article objects", () => {
+  test("200: Responds with an array of article objects", () => {
     return request(app)
       .get("/api/articles")
       .expect(200)
@@ -103,21 +121,7 @@ describe("GET /api/articles", () => {
         });
       });
   });
-  test("200: Responses with articles sorted by create_at with a default order", () => {
-    return request(app)
-      .get("/api/articles?sort_by=created_at")
-      .expect(200)
-      .then((response) => {
-        const { articles } = response.body;
-  
-        expect(articles.length).toBeGreaterThan(0);
-        expect(articles).toBeSorted({ 
-          key: "created_at", 
-          descending: true
-      });
-    });
-  });
-  test("200: Responses with articles sorted by title with an ascending order", () => {
+  test("200: Responds with articles sorted by title with an ascending order", () => {
     return request(app)
       .get("/api/articles?sort_by=title&order=asc")
       .expect(200)
@@ -131,7 +135,51 @@ describe("GET /api/articles", () => {
       });
     });
   });
-  test("200: Responses with articles filtered by topic", () => {
+  test("200: Responds with articles when only sort_by query is provided", () => {
+    return request(app)
+      .get("/api/articles?sort_by=created_at")
+      .expect(200)
+      .then((response) => {
+        const { articles } = response.body;
+  
+        expect(articles.length).toBeGreaterThan(0);
+        expect(articles).toBeSorted({ 
+          key: "created_at", 
+          descending: true
+      });
+    });
+  });
+  test("200: Responds with articles when only order query is provided", () => {
+    return request(app)
+      .get("/api/articles?order=asc")
+      .expect(200)
+      .then((response) => {
+        const { articles } = response.body;
+  
+        expect(articles.length).toBeGreaterThan(0);
+        expect(articles).toBeSorted({ 
+          key: "created_at", 
+          ascending: true  
+        });
+      });
+  });  
+  test("400: Responds with an error when an invalid sort_by is provided", () => {
+    return request(app)
+      .get("/api/articles?sort_by=invalid_sort_by")
+      .expect(400)
+      .then((response) => {
+        expect(response.body.msg).toBe("Bad Request");
+      });
+  });
+  test("400: Responds with an error when an invalid order query is provided", () => {
+    return request(app)
+      .get("/api/articles?order=invalid_order")
+      .expect(400)
+      .then((response) => {
+        expect(response.body.msg).toBe("Bad Request");
+      });
+  });
+  test("200: Responds with articles filtered by topic", () => {
     return request(app)
       .get("/api/articles?topic=cats")
       .expect(200)
@@ -144,7 +192,18 @@ describe("GET /api/articles", () => {
         });
     });
   });
-  test("404: Responses with an error if topic is not found", () => {
+  test("200: Responds with an empty array when topic exists but has no associated articles", () => {
+    return request(app)
+      .get("/api/articles?topic=paper")
+      .expect(200)
+      .then((response) => {
+        const { articles } = response.body;
+  
+        expect(Array.isArray(articles)).toBe(true);
+        expect(articles.length).toBe(0);
+      });
+  });
+  test("404: Responds with an error when topic is not found", () => {
     return request(app)
       .get("/api/articles?topic=dogs")
       .expect(404)
@@ -155,7 +214,7 @@ describe("GET /api/articles", () => {
 });
 
 describe("GET /api/articles/:article_id/comments", () => {
-  test("200: Responses with all comments for an article", () => {
+  test("200: Responds with all comments for an article", () => {
     return request(app)
       .get("/api/articles/3/comments")
       .expect(200)
@@ -174,7 +233,7 @@ describe("GET /api/articles/:article_id/comments", () => {
         });
     });
   });
-  test("200: Responses with an empty array with no associated comments ", () => {
+  test("200: Responds with an empty array with no associated comments ", () => {
     return request(app)
       .get("/api/articles/2/comments")
       .expect(200)
@@ -183,7 +242,7 @@ describe("GET /api/articles/:article_id/comments", () => {
         expect(comments).toEqual([]);
       });
   });
-  test("404: Responses with an error if article ID is not found", () => {
+  test("404: Responds with an error when article ID is not found", () => {
     return request(app)
       .get("/api/articles/999999/comments")
       .expect(404)
@@ -191,7 +250,7 @@ describe("GET /api/articles/:article_id/comments", () => {
         expect(response.body.msg).toBe("Not Found");
       });
   });
-  test("400: Responses with an error if an invalid article ID is provided", () => {
+  test("400: Responds with an error when an invalid article ID is provided", () => {
     return request(app)
       .get("/api/articles/notNumber/comments")
       .expect(400)
@@ -202,7 +261,7 @@ describe("GET /api/articles/:article_id/comments", () => {
 });
 
 describe("POST /api/articles/:article_id/comments", () => {
-  test("201: Responses with the posted comment for an article", () => {
+  test("201: Responds with the posted comment for an article", () => {
     const newComment = {
       username: "butter_bridge",
       body: "This is a new comment"
@@ -224,7 +283,7 @@ describe("POST /api/articles/:article_id/comments", () => {
         expect(comment).toHaveProperty("article_id", 3);
     });
   });
-  test("404: Responses with an error if article ID is not found", () => {
+  test("404: Responds with an error when article ID is not found", () => {
     const newComment = {
       username: "butter_bridge",
       body: "This is a new comment"
@@ -239,7 +298,7 @@ describe("POST /api/articles/:article_id/comments", () => {
         expect(response.body.msg).toBe("Not Found");
       });
   });
-  test("404: Responses with an error if an invalid username is provided", () => {
+  test("404: Responds with an error when an invalid username is provided", () => {
     const newComment = {
       username: "Invalid username",
       body: "This is a new comment"
@@ -257,7 +316,7 @@ describe("POST /api/articles/:article_id/comments", () => {
 });
 
 describe("PATCH /api/articles/:article_id", () => {
-  test("200: Returns updated article with increment votes", () => {
+  test("200: Responds an updated article with increment votes", () => {
     const incrementVotes = {
       inc_votes: 1
     };
@@ -280,7 +339,7 @@ describe("PATCH /api/articles/:article_id", () => {
           });
       });
   });
-  test("200: Returns updated article with decrement votes", () => {
+  test("200: Responds an updated article with decrement votes", () => {
     const decrementVotes = {
       inc_votes: -10
     };
@@ -303,7 +362,7 @@ describe("PATCH /api/articles/:article_id", () => {
           });
       });
   });
-  test("404: Responses with error if article ID is not found", () => {
+  test("404: Responds with error when an article ID is not found", () => {
     return request(app)
       .patch('/api/articles/9999')
       .send({ inc_votes: 1 })
@@ -312,7 +371,7 @@ describe("PATCH /api/articles/:article_id", () => {
         expect(response.body.msg).toBe("Not Found");
       });
   });
-  test("400: Responses with an error if an invalid article ID is provided", () => {
+  test("400: Responds with an error when an invalid article ID is provided", () => {
     return request(app)
       .patch('/api/articles/notNumber')
       .send({ inc_votes: 1 })
@@ -324,7 +383,7 @@ describe("PATCH /api/articles/:article_id", () => {
 });
 
 describe("DELETE /api/comments/:comment_id", () => {
-  test("204: Responses with deleted comments by id", () => {
+  test("204: Responds with deleted comments by id", () => {
     const comment_id = 4;
 
     return request(app)
@@ -334,7 +393,7 @@ describe("DELETE /api/comments/:comment_id", () => {
         expect(response.body).toEqual({});
       });
   });
-  test("404: Responses with an error if comment ID is not found", () => {
+  test("404: Responds with an error when a comment ID is not found", () => {
     return request(app)
       .delete('/api/comments/9999')
       .expect(404)
@@ -342,7 +401,7 @@ describe("DELETE /api/comments/:comment_id", () => {
         expect(response.body.msg).toEqual("Not Found");
       });
   });
-  test("400: Responses with an error if an invalid comment ID is provided", () => {
+  test("400: Responds with an error when an invalid comment ID is provided", () => {
     return request(app)
       .delete('/api/comments/notNumber')
       .expect(400)
@@ -353,7 +412,7 @@ describe("DELETE /api/comments/:comment_id", () => {
 });
 
 describe("GET /api/users", () => {
-  test("200: Responses with an array of user objects", () => {
+  test("200: Responds with an array of user objects", () => {
     return request(app)
       .get("/api/users")
       .expect(200)
@@ -374,7 +433,7 @@ describe("GET /api/users", () => {
 
 
 describe("API error handling", () => {
-  test("404: Responses with an error if the endpoint is incorrect", () => {
+  test("404: Responds with an error when the endpoint is incorrect", () => {
     return request(app)
       .get("/api/no-topics")
       .expect(404)


### PR DESCRIPTION
added tests for GET /api/articles/:article_id to get an article with comment-count
updated model
---------

In addition, 
added missing tests for added sorting queries on GET /api/articles (PR #14), commented by Jo
added missing test for added topic query on /api/articles (PR #15), commented by Kev